### PR TITLE
Deploy v1.0.1

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,6 @@
     "recommendations": [
         "ms-vscode.PowerShell",
         "mhutchie.git-graph",
-        "davidanson.vscode-markdownlint",
-        "huntertran.auto-markdown-toc"
+        "davidanson.vscode-markdownlint"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,8 +15,13 @@
     "editor.autoSurround": "languageDefined",
     // now your double clicks on a variable names include the dollar sign '$'
     // https://twitter.com/TylerLeonhardt/status/1102749805233737729
-	"[powershell]": {
-		"editor.wordSeparators": "`~!@#%^&*()-=+[{]}\\|;:'\",.<>/?"
+    "[powershell]": {
+        "editor.wordSeparators": "`~!@#%^&*()-=+[{]}\\|;:'\",.<>/?"
     },
-    "powershell.scriptAnalysis.settingsPath": "bin\\PSScriptAnalyzerRules.psd1"
+    "powershell.scriptAnalysis.settingsPath": "bin\\PSScriptAnalyzerRules.psd1",
+    "[markdown]": {
+        "editor.wordWrap": "on",
+        "editor.quickSuggestions": false,
+        "editor.insertSpaces": true
+    }
 }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Will provide Verbose messaging during execution.
 ## Notes
 
 If you've downloaded the PowerShell script (or any other) and recieve a "not digitally signed" error due to your execution policy.
-A simple solution is to execute the PowerShell command **[Unblock-File -Path](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/unblock-file?view=powershell-7) `<powershellScriptPath>`**
+A simple solution is to execute the PowerShell command **[Unblock-File -Path](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/unblock-file?view=powershell-7) `<ScriptPath>`**
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Update-AllModules
 
-[![Version Badge](https://img.shields.io/badge/Version-1.0.0-blue)](https://github.com/TrisBits/Update-AllModules/blob/master/src/Update-AllModules.ps1)
+[![Version Badge](https://img.shields.io/badge/Version-1.0.1-blue)](https://github.com/TrisBits/Update-AllModules/blob/master/src/Update-AllModules.ps1)
 <!-- TOC -->
 
-- [Update-AllModules](#update-allmodules)
+- [Update-AllModules](https://github.com/TrisBits/Update-AllModules/blob/master/src/Update-AllModules.ps1)
   - [Description](#description)
   - [Example](#example)
+  - [Notes](#notes)
   - [License](#license)
 
 <!-- /TOC -->
@@ -22,14 +23,19 @@ Will set the PowerShell Gallery as a trusted repository, when run with elevated 
 Executing the following, will update all currently installed modules.
 
 ```powershell
-Update-AllModules
+.\Update-AllModules.ps1
 ```
 
 Will provide Verbose messaging during execution.
 
 ```powershell
-Update-AllModules -Verbose
+.\Update-AllModules -Verbose
 ```
+
+## Notes
+
+If you've downloaded the PowerShell script (or any other) and recieve a "not digitally signed" error due to your execution policy.
+A simple solution is to execute the PowerShell command **[Unblock-File -Path](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/unblock-file?view=powershell-7) `<powershellScriptPath>`**
 
 ## License
 

--- a/src/Update-AllModules.ps1
+++ b/src/Update-AllModules.ps1
@@ -17,7 +17,7 @@
     .NOTES
     Author: TrisBits
     GitHub: https://github.com/TrisBits/Update-AllModules
-    Created: 2020-07-26
+    Created: 2020-07-29
     License: MIT
     Version: 1.0.1
 #>

--- a/src/Update-AllModules.ps1
+++ b/src/Update-AllModules.ps1
@@ -19,7 +19,7 @@
     GitHub: https://github.com/TrisBits/Update-AllModules
     Created: 2020-07-26
     License: MIT
-    Version: 1.0.0
+    Version: 1.0.1
 #>
 
 [CmdletBinding()]

--- a/src/Update-AllModules.ps1
+++ b/src/Update-AllModules.ps1
@@ -81,7 +81,8 @@ PROCESS {
                 else {
                     Write-Verbose -Message "Uninstalling Old Versions for Module: $($installedModule.Name)"
                     Try {
-                        Get-InstalledModule -Name $installedModule.Name -AllVersions | Where-Object { $_.Version -ne $repositoryModule.Version } | Uninstall-Module -Force
+                        # ErrorAction Stop is used for Uninstall-Module to Catch any non-terminating errors due to an in use module
+                        Get-InstalledModule -Name $installedModule.Name -AllVersions | Where-Object { $_.Version -ne $repositoryModule.Version } | Uninstall-Module -Force -ErrorAction Stop
                     }
                     Catch {
                         Write-Warning -Message "$($installedModule.Name) version: $($installedModule.Version) may require manual uninstallation."


### PR DESCRIPTION
- Fixed bug where unfriendly errors may get presented if a module was in use during the uninstall of an old version.  The catch statement now works to show a friendly warning.
- Updates to documentation.